### PR TITLE
hs cardboard fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceRoot}/cmd/build",
+            "env": {},
+            "args": ["dev:createhostedcluster"],
+            "cwd": "${workspaceRoot}"
+        }
+    ]
+}

--- a/cmd/build/ci.go
+++ b/cmd/build/ci.go
@@ -78,21 +78,13 @@ func (ci *CI) Release(ctx context.Context, args []string) error {
 		return err
 	}
 
-	if err := mgr.ParallelDeps(ctx, self,
+	return mgr.ParallelDeps(ctx, self,
 		// Package images have to be built after binary images have been
 		// because the package lockfiles have to be generated from the image manifest hashes
 		// and these are only known after pushing to the target registry.
 		run.Fn2(pushPackage, "test-stub", registry),
 		run.Fn2(pushPackage, "test-stub-multi", registry),
 		run.Fn2(pushPackage, "test-stub-cel", registry),
-		run.Fn2(pushPackage, "remote-phase", registry),
-	); err != nil {
-		return err
-	}
-
-	// This needs to be separate because the remote-phase package image has to be pushed before
-	// the lockfile of the package-operator package image can be regenerated.
-	return mgr.SerialDeps(ctx, self,
 		run.Fn2(pushPackage, "package-operator", registry),
 	)
 }

--- a/cmd/build/cluster.go
+++ b/cmd/build/cluster.go
@@ -167,18 +167,9 @@ func (c *Cluster) loadImages(ctx context.Context, registryPort int32) error {
 	}
 
 	if err := mgr.ParallelDeps(ctx, self,
-		run.Fn2(pushPackage, "remote-phase", registry),
 		run.Fn2(pushPackage, "test-stub", registry),
 		run.Fn2(pushPackage, "test-stub-multi", registry),
 		run.Fn2(pushPackage, "test-stub-cel", registry),
-	); err != nil {
-		return err
-	}
-
-	// This needs to be separate because the remote-phase package image has to be pushed before
-	// downstream dependencies of the package-operator package image can be regenerated.
-	// *very very sad @erdii noises*
-	if err := mgr.ParallelDeps(ctx, self,
 		run.Fn2(pushPackage, "package-operator", registry),
 	); err != nil {
 		return err

--- a/cmd/build/dev.go
+++ b/cmd/build/dev.go
@@ -281,7 +281,7 @@ func (dev *Dev) Run(ctx context.Context, args []string) error {
 		"-namespace", "package-operator-system",
 		"-enable-leader-election=true",
 		"-registry-host-overrides", "quay.io=localhost:5001",
-		"--remote-phase-package-image", imageRegistry() + "/remote-phase-package:" + appVersion,
+		"--remote-phase-package-image", imageRegistry() + "/package-operator-package:" + appVersion,
 	}
 
 	return unix.Exec(absGoBinPath, goArgs, os.Environ())

--- a/cmd/build/package.go
+++ b/cmd/build/package.go
@@ -18,11 +18,12 @@ func buildPackage(ctx context.Context, name, registry string) error {
 
 	deps := []run.Dependency{}
 
-	switch name {
-	case "remote-phase":
-		deps = append(deps, run.Meth(generate, generate.remotePhaseFiles))
-	case "package-operator":
-		deps = append(deps, run.Meth(generate, generate.packageOperatorPackageFiles))
+	if name == "package-operator" {
+		deps = append(deps,
+			run.Meth(generate, generate.remotePhaseComponentFiles),
+			run.Meth(generate, generate.hostedClusterComponentFiles),
+			run.Meth(generate, generate.packageOperatorPackageFiles),
+		)
 	}
 
 	self := run.Fn2(buildPackage, name, registry)


### PR DESCRIPTION
- **Bump k8s.io/apiserver from 0.29.2 to 0.29.3 in /pkg (#1023)**
- **Bump k8s.io/apiextensions-apiserver from 0.29.2 to 0.29.3 in /apis (#1019)**
- **Setup Hypershift development environment (#959)**
- **[ci/testing] do not fail the CI for failed codecov uploads when a fork is tested (#1035)**
- **Bump github.com/docker/cli from 25.0.4+incompatible to 25.0.5+incompatible (#1036)**
- **Bump github.com/docker/docker from 25.0.4+incompatible to 25.0.5+incompatible (#1037)**
- **Move remote-phase package as component of package-operator package**
- **Remote phase manager is now successfully deployed using multi-component package**
- **Hosted cluster manager is built and deployed using multi-component package for the first time**
- **Code improvements and updates to tests**
- **Fix missing refs**
- **f**
